### PR TITLE
Implement keysalts tuple reading

### DIFF
--- a/ext/rkerberos/config.c
+++ b/ext/rkerberos/config.c
@@ -1,6 +1,7 @@
 #include <rkerberos.h>
 
 VALUE cKadm5Config;
+VALUE cKeySalt;
 
 static void rkadm5_config_free(RUBY_KADM5_CONFIG* ptr){
   if(!ptr)
@@ -19,6 +20,15 @@ static VALUE rkadm5_config_allocate(VALUE klass){
   RUBY_KADM5_CONFIG* ptr = malloc(sizeof(RUBY_KADM5_CONFIG));
   memset(ptr, 0, sizeof(RUBY_KADM5_CONFIG));
   return Data_Wrap_Struct(klass, 0, rkadm5_config_free, ptr);
+}
+
+// Helper function to create a KeySalt instance
+static VALUE rkeysalt_new(krb5_enctype enctype, krb5_int32 salttype){
+  VALUE obj = rb_class_new_instance(0, NULL, cKeySalt);
+  rb_iv_set(obj, "@enctype", INT2FIX(enctype));
+  rb_iv_set(obj, "@salttype", INT2FIX(salttype));
+  rb_obj_freeze(obj);
+  return obj;
 }
 
 /*
@@ -150,11 +160,22 @@ static VALUE rkadm5_config_initialize(VALUE self){
   else
     rb_iv_set(self, "@num_keysalts", Qnil);
 
-  // Not very useful at the moment. How do you iterate over an enum in C?
-  if(ptr->config.keysalts)
-    rb_iv_set(self, "@keysalts", INT2FIX(ptr->config.keysalts));
-  else
+  if(ptr->config.keysalts && ptr->config.num_keysalts > 0){
+    VALUE keysalts_array = rb_ary_new();
+    int i;
+
+    for(i = 0; i < ptr->config.num_keysalts; i++) {
+      VALUE keysalt = rkeysalt_new(
+        ptr->config.keysalts[i].ks_enctype,
+        ptr->config.keysalts[i].ks_salttype
+      );
+      rb_ary_push(keysalts_array, keysalt);
+    }
+
+    rb_iv_set(self, "@keysalts", keysalts_array);
+  }else{
     rb_iv_set(self, "@keysalts", Qnil);
+  }
 
   // This is read only data
   rb_obj_freeze(self);
@@ -259,6 +280,7 @@ static VALUE rkadm5_config_inspect(VALUE self){
 }
 
 void Init_config(){
+  // Define Config class
   cKadm5Config = rb_define_class_under(cKadm5, "Config", rb_cObject);
 
   // Allocation function
@@ -296,4 +318,9 @@ void Init_config(){
   rb_define_attr(cKadm5Config, "num_keysalts", 1, 0);
   rb_define_attr(cKadm5Config, "realm", 1, 0);
   rb_define_attr(cKadm5Config, "stash_file", 1, 0);
+
+  // Define KeySalt class
+  cKeySalt = rb_define_class_under(cKadm5, "KeySalt", rb_cObject);
+  rb_define_attr(cKeySalt, "enctype", 1, 0);
+  rb_define_attr(cKeySalt, "salttype", 1, 0);
 }

--- a/ext/rkerberos/rkerberos.h
+++ b/ext/rkerberos/rkerberos.h
@@ -35,6 +35,7 @@ extern VALUE cKadm5;
 extern VALUE cKadm5Config;
 extern VALUE cKadm5Exception;
 extern VALUE cKadm5Policy;
+extern VALUE cKeySalt;
 
 // Kerberos::Krb5
 typedef struct {


### PR DESCRIPTION
This implements a new KeySalt data type to map to the `krb5_key_salt_tuple` enum. It's then converted in an array.

The code was largely generated by Claude Code. It recommended to use hashes, but I chose the explicit objects. This was also recommended in the GitHub issue. It generated a KeySaltTuple class, but I renamed it KeySalt since I think that creates a more native Ruby feeling.

Assisted-By: Claude Code
Fixes: 10f93eb9edc1 ("Add modified files back into project.")
Fixes: #27