### PR TITLE
Replace deprecated Data_Get_Struct with type-safe TypedData_Get_Struct

### DIFF
--- a/ext/rkerberos/ccache.c
+++ b/ext/rkerberos/ccache.c
@@ -19,11 +19,22 @@ static void rkrb5_ccache_free(RUBY_KRB5_CCACHE* ptr){
   free(ptr);
 }
 
+const rb_data_type_t krb5_ccache_type = {
+  .wrap_struct_name = "krb5_ccache",
+  .function = {
+    .dfree = (void (*)(void*))rkrb5_ccache_free,
+    .dsize = NULL,
+    .dmark = NULL,
+  },
+  .data = NULL,
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY
+};
+
 // Allocation function for the Kerberos::Krb5::CCache class.
 static VALUE rkrb5_ccache_allocate(VALUE klass){
   RUBY_KRB5_CCACHE* ptr = malloc(sizeof(RUBY_KRB5_CCACHE));
   memset(ptr, 0, sizeof(RUBY_KRB5_CCACHE));
-  return Data_Wrap_Struct(klass, 0, rkrb5_ccache_free, ptr);
+  return TypedData_Wrap_Struct(klass, &krb5_ccache_type, ptr);
 }
 
 /*
@@ -46,7 +57,7 @@ static VALUE rkrb5_ccache_initialize(int argc, VALUE* argv, VALUE self){
   krb5_error_code kerror;
   VALUE v_principal, v_name;
 
-  Data_Get_Struct(self, RUBY_KRB5_CCACHE, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5_CCACHE, &krb5_ccache_type, ptr);
 
   rb_scan_args(argc, argv, "02", &v_principal, &v_name);
 
@@ -108,7 +119,7 @@ static VALUE rkrb5_ccache_initialize(int argc, VALUE* argv, VALUE self){
 static VALUE rkrb5_ccache_close(VALUE self){
   RUBY_KRB5_CCACHE* ptr;
 
-  Data_Get_Struct(self, RUBY_KRB5_CCACHE, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5_CCACHE, &krb5_ccache_type, ptr);
 
   if(!ptr->ctx)
     return self;
@@ -141,7 +152,7 @@ static VALUE rkrb5_ccache_close(VALUE self){
 static VALUE rkrb5_ccache_default_name(VALUE self){
   RUBY_KRB5_CCACHE* ptr;
 
-  Data_Get_Struct(self, RUBY_KRB5_CCACHE, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5_CCACHE, &krb5_ccache_type, ptr);
 
   if(!ptr->ctx)
     rb_raise(cKrb5Exception, "no context has been established");
@@ -160,7 +171,7 @@ static VALUE rkrb5_ccache_primary_principal(VALUE self){
   krb5_error_code kerror;
   char* name;
 
-  Data_Get_Struct(self, RUBY_KRB5_CCACHE, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5_CCACHE, &krb5_ccache_type, ptr);
 
   if(!ptr->ctx)
     rb_raise(cKrb5Exception, "no context has been established");
@@ -193,7 +204,7 @@ static VALUE rkrb5_ccache_destroy(VALUE self){
   krb5_error_code kerror;
   VALUE v_bool = Qtrue;
 
-  Data_Get_Struct(self, RUBY_KRB5_CCACHE, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5_CCACHE, &krb5_ccache_type, ptr);
 
   if(!ptr->ctx)
     rb_raise(cKrb5Exception, "no context has been established");

--- a/ext/rkerberos/config.c
+++ b/ext/rkerberos/config.c
@@ -14,11 +14,22 @@ static void rkadm5_config_free(RUBY_KADM5_CONFIG* ptr){
   free(ptr);
 }
 
+const rb_data_type_t kadm5_config_type = {
+  .wrap_struct_name = "kadm5_config",
+  .function = {
+    .dfree = (void (*)(void*))rkadm5_config_free,
+    .dsize = NULL,
+    .dmark = NULL,
+  },
+  .data = NULL,
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY
+};
+
 // Allocation function for the Kerberos::Krb5 class.
 static VALUE rkadm5_config_allocate(VALUE klass){
   RUBY_KADM5_CONFIG* ptr = malloc(sizeof(RUBY_KADM5_CONFIG));
   memset(ptr, 0, sizeof(RUBY_KADM5_CONFIG));
-  return Data_Wrap_Struct(klass, 0, rkadm5_config_free, ptr);
+  return TypedData_Wrap_Struct(klass, &kadm5_config_type, ptr);
 }
 
 /*
@@ -33,7 +44,7 @@ static VALUE rkadm5_config_initialize(VALUE self){
   RUBY_KADM5_CONFIG* ptr;
   krb5_error_code kerror;
 
-  Data_Get_Struct(self, RUBY_KADM5_CONFIG, ptr);
+  TypedData_Get_Struct(self, RUBY_KADM5_CONFIG, &kadm5_config_type, ptr);
 
   kerror = krb5_init_context(&ptr->ctx);
 

--- a/ext/rkerberos/context.c
+++ b/ext/rkerberos/context.c
@@ -13,11 +13,22 @@ static void rkrb5_context_free(RUBY_KRB5_CONTEXT* ptr){
   free(ptr);
 }
 
+const rb_data_type_t krb5_context_type = {
+  .wrap_struct_name = "krb5_context",
+  .function = {
+    .dfree = (void (*)(void*))rkrb5_context_free,
+    .dsize = NULL,
+    .dmark = NULL,
+  },
+  .data = NULL,
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY
+};
+
 // Allocation function for the Kerberos::Krb5::Context class.
 static VALUE rkrb5_context_allocate(VALUE klass){
   RUBY_KRB5_CONTEXT* ptr = malloc(sizeof(RUBY_KRB5_CONTEXT));
   memset(ptr, 0, sizeof(RUBY_KRB5_CONTEXT));
-  return Data_Wrap_Struct(klass, 0, rkrb5_context_free, ptr);
+  return TypedData_Wrap_Struct(klass, &krb5_context_type, ptr);
 }
 
 /*
@@ -29,7 +40,7 @@ static VALUE rkrb5_context_allocate(VALUE klass){
 static VALUE rkrb5_context_close(VALUE self){
   RUBY_KRB5_CONTEXT* ptr;
 
-  Data_Get_Struct(self, RUBY_KRB5_CONTEXT, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5_CONTEXT, &krb5_context_type, ptr);
 
   if(ptr->ctx)
     krb5_free_context(ptr->ctx);
@@ -52,7 +63,7 @@ static VALUE rkrb5_context_initialize(VALUE self){
   RUBY_KRB5_CONTEXT* ptr;
   krb5_error_code kerror;
 
-  Data_Get_Struct(self, RUBY_KRB5_CONTEXT, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5_CONTEXT, &krb5_context_type, ptr);
 
   kerror = krb5_init_context(&ptr->ctx);
 

--- a/ext/rkerberos/kadm5.c
+++ b/ext/rkerberos/kadm5.c
@@ -27,11 +27,22 @@ static void rkadm5_free(RUBY_KADM5* ptr){
   free(ptr);
 }
 
+const rb_data_type_t kadm5_type = {
+  .wrap_struct_name = "kadm5",
+  .function = {
+    .dfree = (void (*)(void*))rkadm5_free,
+    .dsize = NULL,
+    .dmark = NULL,
+  },
+  .data = NULL,
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY
+};
+
 // Allocation function for the Kerberos::Kadm5 class.
 static VALUE rkadm5_allocate(VALUE klass){
   RUBY_KADM5* ptr = malloc(sizeof(RUBY_KADM5));
   memset(ptr, 0, sizeof(RUBY_KADM5));
-  return Data_Wrap_Struct(klass, 0, rkadm5_free, ptr);
+  return TypedData_Wrap_Struct(klass, &kadm5_type, ptr);
 }
 
 /*
@@ -65,7 +76,7 @@ static VALUE rkadm5_initialize(VALUE self, VALUE v_opts){
   char* service = NULL;
   krb5_error_code kerror;
 
-  Data_Get_Struct(self, RUBY_KADM5, ptr);
+  TypedData_Get_Struct(self, RUBY_KADM5, &kadm5_type, ptr);
   Check_Type(v_opts, T_HASH);
 
   v_principal = rb_hash_aref2(v_opts, "principal");
@@ -210,7 +221,7 @@ static VALUE rkadm5_set_password(VALUE self, VALUE v_user, VALUE v_pass){
   Check_Type(v_user, T_STRING);
   Check_Type(v_pass, T_STRING);
 
-  Data_Get_Struct(self, RUBY_KADM5, ptr);
+  TypedData_Get_Struct(self, RUBY_KADM5, &kadm5_type, ptr);
   user = StringValueCStr(v_user);
   pass = StringValueCStr(v_pass);
 
@@ -252,7 +263,7 @@ static VALUE rkadm5_create_principal(int argc, VALUE* argv, VALUE self){
   krb5_error_code kerror;
   VALUE v_user, v_pass, v_db_args;
 
-  Data_Get_Struct(self, RUBY_KADM5, ptr);
+  TypedData_Get_Struct(self, RUBY_KADM5, &kadm5_type, ptr);
 
   rb_scan_args(argc, argv, "21", &v_user, &v_pass, &v_db_args);
   Check_Type(v_user, T_STRING);
@@ -296,7 +307,7 @@ static VALUE rkadm5_delete_principal(VALUE self, VALUE v_user){
   char* user;
   krb5_error_code kerror;
 
-  Data_Get_Struct(self, RUBY_KADM5, ptr);
+  TypedData_Get_Struct(self, RUBY_KADM5, &kadm5_type, ptr);
   Check_Type(v_user, T_STRING);
   user = StringValueCStr(v_user);
 
@@ -328,7 +339,7 @@ static VALUE rkadm5_delete_principal(VALUE self, VALUE v_user){
  */
 static VALUE rkadm5_close(VALUE self){
   RUBY_KADM5* ptr;
-  Data_Get_Struct(self, RUBY_KADM5, ptr);
+  TypedData_Get_Struct(self, RUBY_KADM5, &kadm5_type, ptr);
 
   if(ptr->princ)
     krb5_free_principal(ptr->ctx, ptr->princ);
@@ -421,7 +432,7 @@ static VALUE rkadm5_find_principal(VALUE self, VALUE v_user){
   kadm5_principal_ent_rec ent;
   krb5_error_code kerror;
 
-  Data_Get_Struct(self, RUBY_KADM5, ptr);
+  TypedData_Get_Struct(self, RUBY_KADM5, &kadm5_type, ptr);
   Check_Type(v_user, T_STRING);
   user = StringValueCStr(v_user);
 
@@ -477,7 +488,7 @@ static VALUE rkadm5_get_principal(VALUE self, VALUE v_user){
   kadm5_principal_ent_rec ent;
   krb5_error_code kerror;
 
-  Data_Get_Struct(self, RUBY_KADM5, ptr);
+  TypedData_Get_Struct(self, RUBY_KADM5, &kadm5_type, ptr);
   Check_Type(v_user, T_STRING);
   user = StringValueCStr(v_user);
 
@@ -534,7 +545,7 @@ static VALUE rkadm5_create_policy(VALUE self, VALUE v_policy){
   long mask = KADM5_POLICY;
   VALUE v_name, v_min_classes, v_min_life, v_max_life, v_min_length, v_history_num;
 
-  Data_Get_Struct(self, RUBY_KADM5, ptr);
+  TypedData_Get_Struct(self, RUBY_KADM5, &kadm5_type, ptr);
 
   // Allow a hash or a Policy object
   if(rb_obj_is_kind_of(v_policy, rb_cHash)){
@@ -601,7 +612,7 @@ static VALUE rkadm5_delete_policy(VALUE self, VALUE v_policy){
   kadm5_ret_t kerror;
   char* policy;
 
-  Data_Get_Struct(self, RUBY_KADM5, ptr);
+  TypedData_Get_Struct(self, RUBY_KADM5, &kadm5_type, ptr);
 
   policy = StringValueCStr(v_policy);
 
@@ -630,7 +641,7 @@ static VALUE rkadm5_get_policy(VALUE self, VALUE v_name){
   kadm5_ret_t kerror;
   char* policy_name;
 
-  Data_Get_Struct(self, RUBY_KADM5, ptr);
+  TypedData_Get_Struct(self, RUBY_KADM5, &kadm5_type, ptr);
   memset(&ent, 0, sizeof(ent));
 
   if(!ptr->ctx)
@@ -682,7 +693,7 @@ static VALUE rkadm5_find_policy(VALUE self, VALUE v_name){
   kadm5_ret_t kerror;
   char* policy_name;
 
-  Data_Get_Struct(self, RUBY_KADM5, ptr);
+  TypedData_Get_Struct(self, RUBY_KADM5, &kadm5_type, ptr);
   memset(&ent, 0, sizeof(ent));
 
   if(!ptr->ctx)
@@ -738,8 +749,8 @@ static VALUE rkadm5_modify_policy(VALUE self, VALUE v_policy){
   kadm5_ret_t kerror;
   long mask = KADM5_POLICY;
 
-  Data_Get_Struct(self, RUBY_KADM5, ptr);
-  Data_Get_Struct(v_policy, RUBY_KADM5_POLICY, pptr);
+  TypedData_Get_Struct(self, RUBY_KADM5, &kadm5_type, ptr);
+  TypedData_Get_Struct(v_policy, RUBY_KADM5_POLICY, &kadm5_policy_type, pptr);
 
   if(!ptr->ctx)
     rb_raise(cKadm5Exception, "no context has been established");
@@ -785,7 +796,7 @@ static VALUE rkadm5_get_policies(int argc, VALUE* argv, VALUE self){
   char* expr;
   int i, count;
 
-  Data_Get_Struct(self, RUBY_KADM5, ptr);
+  TypedData_Get_Struct(self, RUBY_KADM5, &kadm5_type, ptr);
 
   rb_scan_args(argc, argv, "01", &v_expr);
 
@@ -833,7 +844,7 @@ static VALUE rkadm5_get_principals(int argc, VALUE* argv, VALUE self){
   char* expr;
   int i, count;
 
-  Data_Get_Struct(self, RUBY_KADM5, ptr);
+  TypedData_Get_Struct(self, RUBY_KADM5, &kadm5_type, ptr);
 
   rb_scan_args(argc, argv, "01", &v_expr);
 
@@ -882,7 +893,7 @@ static VALUE rkadm5_get_privs(int argc, VALUE* argv, VALUE self){
   long privs;
   int result = 0;
 
-  Data_Get_Struct(self, RUBY_KADM5, ptr);
+  TypedData_Get_Struct(self, RUBY_KADM5, &kadm5_type, ptr);
 
   rb_scan_args(argc, argv, "01", &v_strings);
 
@@ -939,7 +950,7 @@ static VALUE rkadm5_randkey_principal(VALUE self, VALUE v_user){
   char* user;
   int n_keys, i;
 
-  Data_Get_Struct(self, RUBY_KADM5, ptr);
+  TypedData_Get_Struct(self, RUBY_KADM5, &kadm5_type, ptr);
 
   user = StringValueCStr(v_user);
 

--- a/ext/rkerberos/keytab.c
+++ b/ext/rkerberos/keytab.c
@@ -16,11 +16,22 @@ static void rkrb5_keytab_free(RUBY_KRB5_KEYTAB* ptr){
   free(ptr);
 }
 
+const rb_data_type_t krb5_keytab_type = {
+  .wrap_struct_name = "krb5_keytab",
+  .function = {
+    .dfree = (void (*)(void*))rkrb5_keytab_free,
+    .dsize = NULL,
+    .dmark = NULL,
+  },
+  .data = NULL,
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY
+};
+
 // Allocation function for the Kerberos::Krb5::Keytab class.
 static VALUE rkrb5_keytab_allocate(VALUE klass){
   RUBY_KRB5_KEYTAB* ptr = malloc(sizeof(RUBY_KRB5_KEYTAB));
   memset(ptr, 0, sizeof(RUBY_KRB5_KEYTAB));
-  return Data_Wrap_Struct(klass, 0, rkrb5_keytab_free, ptr);
+  return TypedData_Wrap_Struct(klass, &krb5_keytab_type, ptr);
 }
 
 /*
@@ -40,7 +51,7 @@ static VALUE rkrb5_keytab_each(VALUE self){
   krb5_keytab_entry entry;
   char* principal;
 
-  Data_Get_Struct(self, RUBY_KRB5_KEYTAB, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5_KEYTAB, &krb5_keytab_type, ptr);
 
   kerror = krb5_kt_start_seq_get(
     ptr->ctx,
@@ -93,7 +104,7 @@ static VALUE rkrb5_keytab_default_name(VALUE self){
   RUBY_KRB5_KEYTAB* ptr;
   VALUE v_default_name;
 
-  Data_Get_Struct(self, RUBY_KRB5_KEYTAB, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5_KEYTAB, &krb5_keytab_type, ptr);
 
   kerror = krb5_kt_default_name(ptr->ctx, default_name, MAX_KEYTAB_NAME_LEN);
 
@@ -116,7 +127,7 @@ static VALUE rkrb5_keytab_default_name(VALUE self){
 static VALUE rkrb5_keytab_close(VALUE self){
   RUBY_KRB5_KEYTAB* ptr;
 
-  Data_Get_Struct(self, RUBY_KRB5_KEYTAB, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5_KEYTAB, &krb5_keytab_type, ptr);
 
   if(ptr->ctx)
     krb5_free_cred_contents(ptr->ctx, &ptr->creds);
@@ -137,7 +148,7 @@ static VALUE rkrb5_keytab_remove_entry(int argc, VALUE* argv, VALUE self){
   char* name;
   VALUE v_name, v_vno, v_enctype;
 
-  Data_Get_Struct(self, RUBY_KRB5_KEYTAB, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5_KEYTAB, &krb5_keytab_type, ptr);
 
   rb_scan_args(argc, argv, "12", &v_name, &v_vno, &v_enctype);
 
@@ -184,7 +195,7 @@ static VALUE rkrb5_keytab_add_entry(int argc, VALUE* argv, VALUE self){
   char* name;
   VALUE v_name, v_vno, v_enctype;
 
-  Data_Get_Struct(self, RUBY_KRB5_KEYTAB, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5_KEYTAB, &krb5_keytab_type, ptr);
 
   rb_scan_args(argc, argv, "12", &v_name, &v_vno, &v_enctype);
 
@@ -247,7 +258,7 @@ static VALUE rkrb5_keytab_get_entry(int argc, VALUE* argv, VALUE self){
   char* name;
   VALUE v_principal, v_vno, v_enctype, v_entry;
 
-  Data_Get_Struct(self, RUBY_KRB5_KEYTAB, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5_KEYTAB, &krb5_keytab_type, ptr);
 
   rb_scan_args(argc, argv, "12", &v_principal, &v_vno, &v_enctype);
 
@@ -311,7 +322,7 @@ static VALUE rkrb5_keytab_initialize(int argc, VALUE* argv, VALUE self){
   char keytab_name[MAX_KEYTAB_NAME_LEN];
   VALUE v_keytab_name = Qnil;
 
-  Data_Get_Struct(self, RUBY_KRB5_KEYTAB, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5_KEYTAB, &krb5_keytab_type, ptr);
 
   rb_scan_args(argc, argv, "01", &v_keytab_name);
 

--- a/ext/rkerberos/keytab_entry.c
+++ b/ext/rkerberos/keytab_entry.c
@@ -10,11 +10,22 @@ static void rkrb5_kt_entry_free(RUBY_KRB5_KT_ENTRY* ptr){
   free(ptr);
 }
 
+const rb_data_type_t krb5_kt_entry_type = {
+  .wrap_struct_name = "krb5_kt_entry",
+  .function = {
+    .dfree = (void (*)(void*))rkrb5_kt_entry_free,
+    .dsize = NULL,
+    .dmark = NULL,
+  },
+  .data = NULL,
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY
+};
+
 // Allocation function for the Kerberos::Krb5::Keytab::Entry class.
 static VALUE rkrb5_kt_entry_allocate(VALUE klass){
   RUBY_KRB5_KT_ENTRY* ptr = malloc(sizeof(RUBY_KRB5_KT_ENTRY));
   memset(ptr, 0, sizeof(RUBY_KRB5_KT_ENTRY));
-  return Data_Wrap_Struct(klass, 0, rkrb5_kt_entry_free, ptr);
+  return TypedData_Wrap_Struct(klass, &krb5_kt_entry_type, ptr);
 }
 
 /*

--- a/ext/rkerberos/policy.c
+++ b/ext/rkerberos/policy.c
@@ -13,11 +13,22 @@ static void rkadm5_policy_free(RUBY_KADM5_POLICY* ptr){
   free(ptr);
 }
 
+const rb_data_type_t kadm5_policy_type = {
+  .wrap_struct_name = "kadm5_policy",
+  .function = {
+    .dfree = (void (*)(void*))rkadm5_policy_free,
+    .dsize = NULL,
+    .dmark = NULL,
+  },
+  .data = NULL,
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY
+};
+
 // Allocation function for the Kerberos::Kadm5::Policy class.
 static VALUE rkadm5_policy_allocate(VALUE klass){
   RUBY_KADM5_POLICY* ptr = malloc(sizeof(RUBY_KADM5_POLICY));
   memset(ptr, 0, sizeof(RUBY_KADM5_POLICY));
-  return Data_Wrap_Struct(klass, 0, rkadm5_policy_free, ptr);
+  return TypedData_Wrap_Struct(klass, &kadm5_policy_type, ptr);
 }
 
 /*
@@ -45,7 +56,7 @@ static VALUE rkadm5_policy_init(VALUE self, VALUE v_options){
   VALUE v_name, v_minlife, v_maxlife, v_minlength;
   VALUE v_minclasses, v_historynum;
 
-  Data_Get_Struct(self, RUBY_KADM5_POLICY, ptr);
+  TypedData_Get_Struct(self, RUBY_KADM5_POLICY, &kadm5_policy_type, ptr);
 
   Check_Type(v_options, T_HASH);
 

--- a/ext/rkerberos/principal.c
+++ b/ext/rkerberos/principal.c
@@ -16,11 +16,22 @@ static void rkrb5_princ_free(RUBY_KRB5_PRINC* ptr){
   free(ptr);
 }
 
+const rb_data_type_t krb5_princ_type = {
+  .wrap_struct_name = "krb5_princ",
+  .function = {
+    .dfree = (void (*)(void*))rkrb5_princ_free,
+    .dsize = NULL,
+    .dmark = NULL,
+  },
+  .data = NULL,
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY
+};
+
 // Allocation function for the Kerberos::Krb5::Keytab class.
 static VALUE rkrb5_princ_allocate(VALUE klass){
   RUBY_KRB5_PRINC* ptr = malloc(sizeof(RUBY_KRB5_PRINC));
   memset(ptr, 0, sizeof(RUBY_KRB5_PRINC));
-  return Data_Wrap_Struct(klass, 0, rkrb5_princ_free, ptr);
+  return TypedData_Wrap_Struct(klass, &krb5_princ_type, ptr);
 }
 
 /*
@@ -42,7 +53,7 @@ static VALUE rkrb5_princ_initialize(VALUE self, VALUE v_name){
   RUBY_KRB5_PRINC* ptr;
   krb5_error_code kerror;
 
-  Data_Get_Struct(self, RUBY_KRB5_PRINC, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5_PRINC, &krb5_princ_type, ptr);
 
   kerror = krb5_init_context(&ptr->ctx);
 
@@ -93,7 +104,7 @@ static VALUE rkrb5_princ_initialize(VALUE self, VALUE v_name){
  */
 static VALUE rkrb5_princ_get_realm(VALUE self){
   RUBY_KRB5_PRINC* ptr;
-  Data_Get_Struct(self, RUBY_KRB5_PRINC, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5_PRINC, &krb5_princ_type, ptr);
 
   return rb_str_new2(krb5_princ_realm(ptr->ctx, ptr->principal)->data);
 }
@@ -107,7 +118,7 @@ static VALUE rkrb5_princ_get_realm(VALUE self){
 static VALUE rkrb5_princ_set_realm(VALUE self, VALUE v_realm){
   RUBY_KRB5_PRINC* ptr;
 
-  Data_Get_Struct(self, RUBY_KRB5_PRINC, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5_PRINC, &krb5_princ_type, ptr);
 
   Check_Type(v_realm, T_STRING);
 
@@ -127,8 +138,8 @@ static VALUE rkrb5_princ_equal(VALUE self, VALUE v_other){
   RUBY_KRB5_PRINC* ptr2;
   VALUE v_bool = Qfalse;
 
-  Data_Get_Struct(self, RUBY_KRB5_PRINC, ptr1);
-  Data_Get_Struct(v_other, RUBY_KRB5_PRINC, ptr2);
+  TypedData_Get_Struct(self, RUBY_KRB5_PRINC, &krb5_princ_type, ptr1);
+  TypedData_Get_Struct(v_other, RUBY_KRB5_PRINC, &krb5_princ_type, ptr2);
 
   if(krb5_principal_compare(ptr1->ctx, ptr1->principal, ptr2->principal))
     v_bool = Qtrue;

--- a/ext/rkerberos/rkerberos.c
+++ b/ext/rkerberos/rkerberos.c
@@ -39,11 +39,22 @@ static void rkrb5_free(RUBY_KRB5* ptr){
   free(ptr);
 }
 
+const rb_data_type_t krb5_type = {
+  .wrap_struct_name = "krb5",
+  .function = {
+    .dfree = (void (*)(void*))rkrb5_free,
+    .dsize = NULL,
+    .dmark = NULL,
+  },
+  .data = NULL,
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY
+};
+
 // Allocation function for the Kerberos::Krb5 class.
 static VALUE rkrb5_allocate(VALUE klass){
   RUBY_KRB5* ptr = malloc(sizeof(RUBY_KRB5));
   memset(ptr, 0, sizeof(RUBY_KRB5));
-  return Data_Wrap_Struct(klass, 0, rkrb5_free, ptr);
+  return TypedData_Wrap_Struct(klass, &krb5_type, ptr);
 }
 
 /*
@@ -57,7 +68,7 @@ static VALUE rkrb5_initialize(VALUE self){
   RUBY_KRB5* ptr;
   krb5_error_code kerror;
 
-  Data_Get_Struct(self, RUBY_KRB5, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5, &krb5_type, ptr);
 
   kerror = krb5_init_context(&ptr->ctx);
 
@@ -83,7 +94,7 @@ static VALUE rkrb5_get_default_realm(VALUE self){
   char* realm;
   krb5_error_code kerror;
 
-  Data_Get_Struct(self, RUBY_KRB5, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5, &krb5_type, ptr);
 
   kerror = krb5_get_default_realm(ptr->ctx, &realm);
 
@@ -106,7 +117,7 @@ static VALUE rkrb5_set_default_realm(int argc, VALUE* argv, VALUE self){
   char* realm;
   krb5_error_code kerror;
 
-  Data_Get_Struct(self, RUBY_KRB5, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5, &krb5_type, ptr);
 
   rb_scan_args(argc, argv, "01", &v_realm);
 
@@ -150,7 +161,7 @@ static VALUE rkrb5_get_init_creds_keytab(int argc, VALUE* argv, VALUE self){
   krb5_get_init_creds_opt* opt;
   krb5_creds cred;
 
-  Data_Get_Struct(self, RUBY_KRB5, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5, &krb5_type, ptr);
 
   if(!ptr->ctx)
     rb_raise(cKrb5Exception, "no context has been established");
@@ -225,7 +236,7 @@ static VALUE rkrb5_get_init_creds_keytab(int argc, VALUE* argv, VALUE self){
   // Set the credential cache from the supplied Kerberos::Krb5::CredentialsCache
   if(!NIL_P(v_ccache)){
     RUBY_KRB5_CCACHE* ccptr;
-    Data_Get_Struct(v_ccache, RUBY_KRB5_CCACHE, ccptr);
+    TypedData_Get_Struct(v_ccache, RUBY_KRB5_CCACHE, &krb5_ccache_type, ccptr);
 
     kerror = krb5_get_init_creds_opt_set_out_ccache(ptr->ctx, opt, ccptr->ccache);
     if(kerror) {
@@ -286,7 +297,7 @@ static VALUE rkrb5_change_password(VALUE self, VALUE v_old, VALUE v_new){
   old_passwd = StringValueCStr(v_old);
   new_passwd = StringValueCStr(v_new);
 
-  Data_Get_Struct(self, RUBY_KRB5, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5, &krb5_type, ptr);
 
   if(!ptr->ctx)
     rb_raise(cKrb5Exception, "no context has been established");
@@ -340,7 +351,7 @@ static VALUE rkrb5_get_init_creds_passwd(int argc, VALUE* argv, VALUE self){
   char* service;
   krb5_error_code kerror;
 
-  Data_Get_Struct(self, RUBY_KRB5, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5, &krb5_type, ptr);
 
   if(!ptr->ctx)
     rb_raise(cKrb5Exception, "no context has been established");
@@ -393,7 +404,7 @@ static VALUE rkrb5_get_init_creds_passwd(int argc, VALUE* argv, VALUE self){
 static VALUE rkrb5_close(VALUE self){
   RUBY_KRB5* ptr;
 
-  Data_Get_Struct(self, RUBY_KRB5, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5, &krb5_type, ptr);
 
   if(ptr->ctx)
     krb5_free_cred_contents(ptr->ctx, &ptr->creds);
@@ -425,7 +436,7 @@ static VALUE rkrb5_get_default_principal(VALUE self){
   krb5_ccache ccache;
   krb5_error_code kerror;
 
-  Data_Get_Struct(self, RUBY_KRB5, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5, &krb5_type, ptr);
 
   if(!ptr->ctx)
     rb_raise(cKrb5Exception, "no context has been established");
@@ -481,7 +492,7 @@ static VALUE rkrb5_get_permitted_enctypes(VALUE self){
   krb5_enctype* ktypes;
   krb5_error_code kerror;
 
-  Data_Get_Struct(self, RUBY_KRB5, ptr);
+  TypedData_Get_Struct(self, RUBY_KRB5, &krb5_type, ptr);
 
   if(!ptr->ctx)
     rb_raise(cKrb5Exception, "no context has been established");

--- a/ext/rkerberos/rkerberos.h
+++ b/ext/rkerberos/rkerberos.h
@@ -22,6 +22,17 @@ void Init_ccache();
 // Defined in rkerberos.c
 VALUE rb_hash_aref2(VALUE, const char*);
 
+// TypedData type declarations
+extern const rb_data_type_t krb5_type;
+extern const rb_data_type_t krb5_ccache_type;
+extern const rb_data_type_t krb5_context_type;
+extern const rb_data_type_t krb5_keytab_type;
+extern const rb_data_type_t krb5_kt_entry_type;
+extern const rb_data_type_t krb5_princ_type;
+extern const rb_data_type_t kadm5_type;
+extern const rb_data_type_t kadm5_config_type;
+extern const rb_data_type_t kadm5_policy_type;
+
 // Variable declarations
 extern VALUE mKerberos;
 extern VALUE cKrb5;


### PR DESCRIPTION
I've also added a manual commit to strip all trailing whitespace.

Generated-By: Claude Code