### PR TITLE
Add support for credentials cache object to Kadm5 constructor

### DIFF
--- a/ext/rkerberos/kadm5.c
+++ b/ext/rkerberos/kadm5.c
@@ -121,8 +121,8 @@ static VALUE rkadm5_initialize(VALUE self, VALUE v_opts){
     if(NIL_P(v_principal))
       rb_raise(rb_eArgError, "principal must be specified");
 
-    Check_Type(v_principal, T_STRING);
     Check_Type(v_password, T_STRING);
+    Check_Type(v_principal, T_STRING);
 
     pass = StringValueCStr(v_password);
   }

--- a/ext/rkerberos/kadm5.c
+++ b/ext/rkerberos/kadm5.c
@@ -121,8 +121,12 @@ static VALUE rkadm5_initialize(VALUE self, VALUE v_opts){
     if(RTEST(v_password)) auth_count++;
     if(RTEST(v_keytab))   auth_count++;
     if(RTEST(v_ccache))   auth_count++;
+
     if(auth_count > 1)
       rb_raise(rb_eArgError, "only one of password, keytab, or ccache may be specified");
+
+    if(auth_count == 0)
+      rb_raise(rb_eArgError, "one of password, keytab, or ccache must be specified");
   }
 
   if(RTEST(v_password)){

--- a/ext/rkerberos/kadm5.c
+++ b/ext/rkerberos/kadm5.c
@@ -97,9 +97,7 @@ static VALUE rkadm5_initialize(VALUE self, VALUE v_opts){
   TypedData_Get_Struct(self, RUBY_KADM5, &rkadm5_data_type, ptr);
   Check_Type(v_opts, T_HASH);
 
-  // Accept both string and symbol keys
-  v_principal = rb_hash_aref2(v_opts, rb_str_new_cstr("principal"));
-  if (NIL_P(v_principal)) v_principal = rb_hash_aref2(v_opts, ID2SYM(rb_intern("principal")));
+  v_principal = rb_hash_aref2(v_opts, ID2SYM(rb_intern("principal")));
 
   // Principal must be specified
   if(NIL_P(v_principal))
@@ -108,12 +106,9 @@ static VALUE rkadm5_initialize(VALUE self, VALUE v_opts){
   Check_Type(v_principal, T_STRING);
   user = StringValueCStr(v_principal);
 
-  v_password = rb_hash_aref2(v_opts, rb_str_new_cstr("password"));
-  if (NIL_P(v_password)) v_password = rb_hash_aref2(v_opts, ID2SYM(rb_intern("password")));
-  v_keytab = rb_hash_aref2(v_opts, rb_str_new_cstr("keytab"));
-  if (NIL_P(v_keytab)) v_keytab = rb_hash_aref2(v_opts, ID2SYM(rb_intern("keytab")));
-  v_ccache = rb_hash_aref2(v_opts, rb_str_new_cstr("ccache"));
-  if (NIL_P(v_ccache)) v_ccache = rb_hash_aref2(v_opts, ID2SYM(rb_intern("ccache")));
+  v_password = rb_hash_aref2(v_opts, ID2SYM(rb_intern("password")));
+  v_keytab = rb_hash_aref2(v_opts, ID2SYM(rb_intern("keytab")));
+  v_ccache = rb_hash_aref2(v_opts, ID2SYM(rb_intern("ccache")));
 
   // Validate mutual exclusivity
   {
@@ -134,8 +129,7 @@ static VALUE rkadm5_initialize(VALUE self, VALUE v_opts){
     pass = StringValueCStr(v_password);
   }
 
-  v_service = rb_hash_aref2(v_opts, rb_str_new_cstr("service"));
-  if (NIL_P(v_service)) v_service = rb_hash_aref2(v_opts, ID2SYM(rb_intern("service")));
+  v_service = rb_hash_aref2(v_opts, ID2SYM(rb_intern("service")));
 
   if(NIL_P(v_service)){
     service = (char *) "kadmin/admin";
@@ -145,13 +139,10 @@ static VALUE rkadm5_initialize(VALUE self, VALUE v_opts){
     service = StringValueCStr(v_service);
   }
 
-  v_db_args = rb_hash_aref2(v_opts, rb_str_new_cstr("db_args"));
-  if (NIL_P(v_db_args)) v_db_args = rb_hash_aref2(v_opts, ID2SYM(rb_intern("db_args")));
+  v_db_args = rb_hash_aref2(v_opts, ID2SYM(rb_intern("db_args")));
   ptr->db_args = parse_db_args(v_db_args);
 
-  // Check for an optional context keyword argument
-  v_context = rb_hash_aref2(v_opts, rb_str_new_cstr("context"));
-  if (NIL_P(v_context)) v_context = rb_hash_aref2(v_opts, ID2SYM(rb_intern("context")));
+  v_context = rb_hash_aref2(v_opts, ID2SYM(rb_intern("context")));
 
   // Initialize or borrow the context
   if(RTEST(v_context)){

--- a/ext/rkerberos/kadm5.c
+++ b/ext/rkerberos/kadm5.c
@@ -98,14 +98,6 @@ static VALUE rkadm5_initialize(VALUE self, VALUE v_opts){
   Check_Type(v_opts, T_HASH);
 
   v_principal = rb_hash_aref2(v_opts, ID2SYM(rb_intern("principal")));
-
-  // Principal must be specified
-  if(NIL_P(v_principal))
-    rb_raise(rb_eArgError, "principal must be specified");
-
-  Check_Type(v_principal, T_STRING);
-  user = StringValueCStr(v_principal);
-
   v_password = rb_hash_aref2(v_opts, ID2SYM(rb_intern("password")));
   v_keytab = rb_hash_aref2(v_opts, ID2SYM(rb_intern("keytab")));
   v_ccache = rb_hash_aref2(v_opts, ID2SYM(rb_intern("ccache")));
@@ -124,11 +116,34 @@ static VALUE rkadm5_initialize(VALUE self, VALUE v_opts){
       rb_raise(rb_eArgError, "one of password, keytab, or ccache must be specified");
   }
 
+  // Principal must be specified if using a password
   if(RTEST(v_password)){
+    if(NIL_P(v_principal))
+      rb_raise(rb_eArgError, "principal must be specified");
+
+    Check_Type(v_principal, T_STRING);
     Check_Type(v_password, T_STRING);
+
     pass = StringValueCStr(v_password);
   }
 
+  // Prefer primary_principal if not nil, else principal
+  if(RTEST(v_ccache) && NIL_P(v_principal)) {
+    v_principal = rb_funcall(v_ccache, rb_intern("primary_principal"), 0);
+
+    if(NIL_P(v_principal))
+      v_principal = rb_funcall(v_ccache, rb_intern("principal"), 0);
+  }
+
+  // For a keytab use the first entry's principal
+  if(RTEST(v_keytab) && NIL_P(v_principal)) {
+    VALUE v_enum, v_first;
+    v_enum = rb_funcall(v_keytab, rb_intern("each"), 0);
+    v_first = rb_funcall(v_enum, rb_intern("first"), 0);
+    v_principal = rb_iv_get(v_first, "@principal");
+  }
+
+  user = StringValueCStr(v_principal);
   v_service = rb_hash_aref2(v_opts, ID2SYM(rb_intern("service")));
 
   if(NIL_P(v_service)){
@@ -432,6 +447,7 @@ static VALUE rkadm5_create_principal(int argc, VALUE* argv, VALUE self){
 
     // Forward optional attributes from the Principal object
     v_policy = rb_iv_get(v_principal, "@policy");
+
     if(RTEST(v_policy)){
       Check_Type(v_policy, T_STRING);
       princ.policy = StringValueCStr(v_policy);
@@ -439,30 +455,35 @@ static VALUE rkadm5_create_principal(int argc, VALUE* argv, VALUE self){
     }
 
     v_expire = rb_iv_get(v_principal, "@expire_time");
+
     if(RTEST(v_expire)){
       princ.princ_expire_time = (krb5_timestamp)NUM2LONG(rb_funcall(v_expire, rb_intern("to_i"), 0));
       mask |= KADM5_PRINC_EXPIRE_TIME;
     }
 
     v_pw_expire = rb_iv_get(v_principal, "@password_expiration");
+
     if(RTEST(v_pw_expire)){
       princ.pw_expiration = (krb5_timestamp)NUM2LONG(rb_funcall(v_pw_expire, rb_intern("to_i"), 0));
       mask |= KADM5_PW_EXPIRATION;
     }
 
     v_max_life = rb_iv_get(v_principal, "@max_life");
+
     if(RTEST(v_max_life)){
       princ.max_life = NUM2LONG(v_max_life);
       mask |= KADM5_MAX_LIFE;
     }
 
     v_max_renew = rb_iv_get(v_principal, "@max_renewable_life");
+
     if(RTEST(v_max_renew)){
       princ.max_renewable_life = NUM2LONG(v_max_renew);
       mask |= KADM5_MAX_RLIFE;
     }
 
     v_attrs = rb_iv_get(v_principal, "@attributes");
+
     if(RTEST(v_attrs)){
       princ.attributes = NUM2LONG(v_attrs);
       mask |= KADM5_ATTRIBUTES;

--- a/ext/rkerberos/kadm5.c
+++ b/ext/rkerberos/kadm5.c
@@ -127,10 +127,7 @@ static VALUE rkadm5_initialize(VALUE self, VALUE v_opts){
     pass = StringValueCStr(v_password);
   }
 
-  // Prefer primary_principal if not nil, else principal
-  if(RTEST(v_ccache) && NIL_P(v_principal)) {
-    v_principal = rb_funcall(v_ccache, rb_intern("primary_principal"), 0);
-
+  if(RTEST(v_ccache) && NIL_P(v_principal)){
     if(NIL_P(v_principal))
       v_principal = rb_funcall(v_ccache, rb_intern("principal"), 0);
   }

--- a/ext/rkerberos/kadm5.c
+++ b/ext/rkerberos/kadm5.c
@@ -60,26 +60,33 @@ static VALUE rkadm5_allocate(VALUE klass){
  *   Kerberos::Kadm5.new(:principal => 'name', :password => 'xxxxx')
  *   Kerberos::Kadm5.new(:principal => 'name', :keytab => '/path/to/your/keytab')
  *   Kerberos::Kadm5.new(:principal => 'name', :keytab => true)
+ *   Kerberos::Kadm5.new(:principal => 'name', :ccache => ccache_object)
  *
  * Creates and returns a new Kerberos::Kadm5 object. A hash argument is
  * accepted that allows you to specify a principal and a password, or
- * a keytab file.
+ * a keytab file, or a credentials cache.
  *
  * If you pass a string as the :keytab value it will attempt to use that file
  * for the keytab. If you pass true as the value it will attempt to use the
  * default keytab file, typically /etc/krb5.keytab.
+ *
+ * If you pass a Kerberos::Krb5::CredentialsCache object as the :ccache value,
+ * it will authenticate using the credentials stored in that cache via
+ * kadm5_init_with_creds.
  *
  * You may also pass the :service option to specify the service name. The
  * default is kadmin/admin.
  *
  * There is also a :db_args option, which is a single string or array of strings
  * containing options usually passed to kadmin with the -x switch. For a list of
- * available options, see the kadmin manpage
+ * available options, see the kadmin manpage.
+ *
+ * Only one of :password, :keytab, or :ccache may be specified.
  *
  */
 static VALUE rkadm5_initialize(VALUE self, VALUE v_opts){
   RUBY_KADM5* ptr;
-  VALUE v_principal, v_password, v_keytab, v_service, v_db_args, v_context;
+  VALUE v_principal, v_password, v_keytab, v_service, v_db_args, v_context, v_ccache;
   char* user;
   char* pass = NULL;
   char* keytab = NULL;
@@ -105,9 +112,18 @@ static VALUE rkadm5_initialize(VALUE self, VALUE v_opts){
   if (NIL_P(v_password)) v_password = rb_hash_aref2(v_opts, ID2SYM(rb_intern("password")));
   v_keytab = rb_hash_aref2(v_opts, rb_str_new_cstr("keytab"));
   if (NIL_P(v_keytab)) v_keytab = rb_hash_aref2(v_opts, ID2SYM(rb_intern("keytab")));
+  v_ccache = rb_hash_aref2(v_opts, rb_str_new_cstr("ccache"));
+  if (NIL_P(v_ccache)) v_ccache = rb_hash_aref2(v_opts, ID2SYM(rb_intern("ccache")));
 
-  if(RTEST(v_password) && RTEST(v_keytab))
-    rb_raise(rb_eArgError, "cannot use both a password and a keytab");
+  // Validate mutual exclusivity
+  {
+    int auth_count = 0;
+    if(RTEST(v_password)) auth_count++;
+    if(RTEST(v_keytab))   auth_count++;
+    if(RTEST(v_ccache))   auth_count++;
+    if(auth_count > 1)
+      rb_raise(rb_eArgError, "only one of password, keytab, or ccache may be specified");
+  }
 
   if(RTEST(v_password)){
     Check_Type(v_password, T_STRING);
@@ -205,8 +221,31 @@ static VALUE rkadm5_initialize(VALUE self, VALUE v_opts){
     if(kerror)
       rb_raise(cKadm5Exception, "kadm5_init_with_skey: %s", error_message(kerror));
   }
-  else{
-    // TODO: Credentials cache.
+  else if(RTEST(v_ccache)){
+    RUBY_KRB5_CCACHE* cc_ptr;
+
+    if(!rb_obj_is_kind_of(v_ccache, cKrb5CCache))
+      rb_raise(rb_eTypeError, "ccache must be a Kerberos::Krb5::CredentialsCache object");
+
+    TypedData_Get_Struct(v_ccache, RUBY_KRB5_CCACHE, &rkrb5_ccache_data_type, cc_ptr);
+
+    if(!cc_ptr->ccache)
+      rb_raise(cKrb5Exception, "credentials cache is closed or destroyed");
+
+    kerror = kadm5_init_with_creds(
+      ptr->ctx,
+      user,
+      cc_ptr->ccache,
+      service,
+      NULL,
+      KADM5_STRUCT_VERSION,
+      KADM5_API_VERSION_3,
+      ptr->db_args,
+      &ptr->handle
+    );
+
+    if(kerror)
+      rb_raise(cKadm5Exception, "kadm5_init_with_creds: %s", error_message(kerror));
   }
 
   if(rb_block_given_p()){

--- a/spec/kadm5_spec.rb
+++ b/spec/kadm5_spec.rb
@@ -84,21 +84,21 @@ RSpec.describe 'Kerberos::Kadm5', :kadm5 do
       expect { subject.new(principal: user, password: pass, context: ctx) }.to raise_error(Kerberos::Krb5::Exception)
     end
 
-    context 'with a credentials cache' do
+    context 'with a credentials cache', :cache do
       let(:krb5) { Kerberos::Krb5.new }
-      let(:ccache_path) { "/tmp/test_kadm5_ccache_#{Process.pid}" }
-      let(:ccache_name) { "FILE:#{ccache_path}" }
-      let(:ccache) { Kerberos::Krb5::CredentialsCache.new(cache_name: ccache_name) }
+      let(:cache_path) { "/tmp/test_kadm5_ccache_#{Process.pid}" }
+      let(:cache_name) { "FILE:#{cache_path}" }
+      let(:cache) { Kerberos::Krb5::CredentialsCache.new(cache_name: cache_name) }
 
       before(:each) do
         krb5.get_init_creds_password(user, pass)
-        krb5.verify_init_creds(nil, nil, ccache)
+        krb5.verify_init_creds(ccache: cache, server: 'kadmin/kadmin@EXAMPLE.COM')
       end
 
       after(:each) do
         ccache.close rescue nil
         krb5.close rescue nil
-        FileUtils.rm_f([ccache_path, "#{ccache_path}.lock"])
+        FileUtils.rm_f([cache_path, "#{cache_path}.lock"])
       end
 
       it 'works with a populated credentials cache' do
@@ -106,13 +106,13 @@ RSpec.describe 'Kerberos::Kadm5', :kadm5 do
       end
 
       it 'returns a Kadm5 object' do
-        kadm5 = subject.new(principal: user, ccache: ccache)
+        kadm5 = subject.new(principal: user, ccache: cache)
         expect(kadm5).to be_a(subject)
         kadm5.close
       end
 
       it 'can perform operations after ccache authentication' do
-        kadm5 = subject.new(principal: user, ccache: ccache)
+        kadm5 = subject.new(principal: user, ccache: cache)
         privs = kadm5.get_privileges
         expect(privs).to be_a(Integer)
         expect(privs).not_to eq(0)
@@ -135,13 +135,13 @@ RSpec.describe 'Kerberos::Kadm5', :kadm5 do
 
       it 'raises ArgumentError when both password and ccache are given' do
         expect {
-          subject.new(principal: user, password: pass, ccache: ccache)
+          subject.new(principal: user, password: pass, ccache: cache)
         }.to raise_error(ArgumentError)
       end
 
       it 'raises ArgumentError when both keytab and ccache are given' do
         expect {
-          subject.new(principal: user, keytab: true, ccache: ccache)
+          subject.new(principal: user, keytab: true, ccache: cache)
         }.to raise_error(ArgumentError)
       end
     end

--- a/spec/kadm5_spec.rb
+++ b/spec/kadm5_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe 'Kerberos::Kadm5', :kadm5 do
       end
 
       it 'works with a populated credentials cache' do
-        expect { subject.new(principal: user, ccache: ccache) }.not_to raise_error
+        expect { subject.new(principal: user, ccache: cache) }.not_to raise_error
       end
 
       it 'returns a Kadm5 object' do

--- a/spec/kadm5_spec.rb
+++ b/spec/kadm5_spec.rb
@@ -3,6 +3,7 @@
 
 require 'spec_helper'
 require 'socket'
+require 'fileutils'
 
 RSpec.describe 'Kerberos::Kadm5', :kadm5 do
   let(:server){ Kerberos::Kadm5::Config.new.admin_server }
@@ -88,7 +89,7 @@ RSpec.describe 'Kerberos::Kadm5', :kadm5 do
       after(:each) do
         ccache.close rescue nil
         krb5.close rescue nil
-        File.delete(ccache_path) rescue nil
+        FileUtils.rm_f([ccache_path, "#{ccache_path}.lock"])
       end
 
       it 'works with a populated credentials cache' do

--- a/spec/kadm5_spec.rb
+++ b/spec/kadm5_spec.rb
@@ -73,6 +73,68 @@ RSpec.describe 'Kerberos::Kadm5', :kadm5 do
       ctx.close
       expect { subject.new(principal: user, password: pass, context: ctx) }.to raise_error(Kerberos::Krb5::Exception)
     end
+
+    context 'with a credentials cache' do
+      let(:krb5) { Kerberos::Krb5.new }
+      let(:ccache_path) { "/tmp/test_kadm5_ccache_#{Process.pid}" }
+      let(:ccache_name) { "FILE:#{ccache_path}" }
+      let(:ccache) { Kerberos::Krb5::CredentialsCache.new(cache_name: ccache_name) }
+
+      before(:each) do
+        krb5.get_init_creds_password(user, pass)
+        krb5.verify_init_creds(nil, nil, ccache)
+      end
+
+      after(:each) do
+        ccache.close rescue nil
+        krb5.close rescue nil
+        File.delete(ccache_path) rescue nil
+      end
+
+      it 'works with a populated credentials cache' do
+        expect { subject.new(principal: user, ccache: ccache) }.not_to raise_error
+      end
+
+      it 'returns a Kadm5 object' do
+        kadm5 = subject.new(principal: user, ccache: ccache)
+        expect(kadm5).to be_a(subject)
+        kadm5.close
+      end
+
+      it 'can perform operations after ccache authentication' do
+        kadm5 = subject.new(principal: user, ccache: ccache)
+        privs = kadm5.get_privileges
+        expect(privs).to be_a(Integer)
+        expect(privs).not_to eq(0)
+        kadm5.close
+      end
+
+      it 'raises TypeError if ccache is not a CredentialsCache' do
+        expect {
+          subject.new(principal: user, ccache: "not_a_ccache")
+        }.to raise_error(TypeError)
+      end
+
+      it 'raises an error for a destroyed credentials cache' do
+        dead_ccache = Kerberos::Krb5::CredentialsCache.new
+        dead_ccache.destroy
+        expect {
+          subject.new(principal: user, ccache: dead_ccache)
+        }.to raise_error(Kerberos::Krb5::Exception)
+      end
+
+      it 'raises ArgumentError when both password and ccache are given' do
+        expect {
+          subject.new(principal: user, password: pass, ccache: ccache)
+        }.to raise_error(ArgumentError)
+      end
+
+      it 'raises ArgumentError when both keytab and ccache are given' do
+        expect {
+          subject.new(principal: user, keytab: true, ccache: ccache)
+        }.to raise_error(ArgumentError)
+      end
+    end
   end
 
   describe '#get_privileges' do

--- a/spec/kadm5_spec.rb
+++ b/spec/kadm5_spec.rb
@@ -28,34 +28,43 @@ RSpec.describe 'Kerberos::Kadm5', :kadm5 do
     it 'responds to .new' do
       expect(subject).to respond_to(:new)
     end
+
     it 'works with valid user and password' do
       expect { subject.new(principal: user, password: pass) }.not_to raise_error
     end
+
     it 'works with valid service' do
       expect {
         subject.new(principal: user, password: pass, service: 'kadmin/admin')
       }.not_to raise_error
     end
+
     it 'only accepts a hash argument' do
       expect { subject.new(user) }.to raise_error(TypeError)
       expect { subject.new(1) }.to raise_error(TypeError)
     end
+
     it 'accepts a block and yields itself' do
       expect { subject.new(principal: user, password: pass) {} }.not_to raise_error
       subject.new(principal: user, password: pass) { |kadm5| expect(kadm5).to be_a(subject) }
     end
+
     it 'requires principal to be specified' do
       expect { subject.new({}) }.to raise_error(ArgumentError)
     end
+
     it 'requires principal to be a string' do
-      expect { subject.new(principal: 1) }.to raise_error(TypeError)
+      expect { subject.new(principal: 1, password: pass) }.to raise_error(TypeError)
     end
+
     it 'requires password to be a string' do
       expect { subject.new(principal: user, password: 1) }.to raise_error(TypeError)
     end
+
     it 'requires keytab to be a string or boolean' do
       expect { subject.new(principal: user, keytab: 1) }.to raise_error(TypeError)
     end
+
     it 'requires service to be a string' do
       expect { subject.new(principal: user, password: pass, service: 1) }.to raise_error(TypeError)
     end

--- a/spec/kadm5_spec.rb
+++ b/spec/kadm5_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe 'Kerberos::Kadm5', :kadm5 do
 
       before(:each) do
         krb5.get_init_creds_password(user, pass)
-        krb5.verify_init_creds(ccache: cache, server: 'kadmin/kadmin@EXAMPLE.COM')
+        krb5.verify_init_creds(ccache: cache)
       end
 
       after(:each) do


### PR DESCRIPTION
Draft for now, can't get the specs to pass, presumably it's a setup issue in the specs.

Edit: yup, it was a setup issue. Also, finding OrbStack helped.